### PR TITLE
[device/celestica]: Add platform-specific firmware management API

### DIFF
--- a/device/celestica/x86_64-cel_e1031-r0/plugins/fwutil.py
+++ b/device/celestica/x86_64-cel_e1031-r0/plugins/fwutil.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python
+
+import sys
+import os.path
+import subprocess
+import click
+import os
+
+
+class FwUtil():
+    """Platform-specific FwUtil class"""
+
+    def __init__(self):
+        self.bios_version_path = "/sys/class/dmi/id/bios_version"
+        self.smc_cpld_e1031_path = "/sys/devices/platform/e1031.smc/version"
+        self.mmc_cpld_e1031_path = "/sys/devices/platform/e1031.smc/getreg"
+
+    # Run bash command and print output to stdout
+    def run_command(self, command):
+        click.echo(click.style("Command: ", fg='cyan') +
+                   click.style(command, fg='green'))
+
+        proc = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE)
+        (out, err) = proc.communicate()
+        click.echo("")
+        click.echo(out)
+
+        if proc.returncode != 0:
+            return False
+        return True
+
+    # Read register and resurn value
+    def __get_register_value(self, path, register):
+        cmd = "echo {1} > {0}; cat {0}".format(path, register)
+        p = subprocess.Popen(
+            cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        raw_data, err = p.communicate()
+        if err is not '':
+            return None
+        return raw_data.strip()
+
+    # Get BIOS firmware version
+    def get_bios_version(self):
+        try:
+            with open(self.bios_version_path, 'r') as fd:
+                bios_version = fd.read()
+                return bios_version.strip()
+        except Exception, e:
+            return None
+
+    # Get CPLD firmware version
+    def get_cpld_version(self):
+        try:
+            with open(self.smc_cpld_e1031_path, 'r') as fd:
+                smc_cpld_version = fd.read()
+
+            smc_cpld_version = "{}.{}".format(int(smc_cpld_version[2], 16), int(
+                smc_cpld_version[3], 16)) if smc_cpld_version is not None else smc_cpld_version
+
+            mmc_cpld_version = self.__get_register_value(
+                self.mmc_cpld_e1031_path, '0x100')
+            mmc_cpld_version = "{}.{}".format(int(mmc_cpld_version[2], 16), int(
+                mmc_cpld_version[3], 16)) if mmc_cpld_version is not None else mmc_cpld_version
+
+            cpld_version = dict()
+            cpld_version["SMC"] = str(smc_cpld_version)
+            cpld_version["MMC"] = str(mmc_cpld_version)
+
+            return cpld_version
+        except Exception, e:
+            return None
+
+    def get_module_list(self):
+        """
+        Retrieves the list of module that available on the device
+
+        :return: A list of module
+        """
+        return ["BIOS", "CPLD"]
+
+    def get_fw_version(self, module_name):
+        """
+        Retrieves the firmware version of module
+
+        :param module_name: A string, module name
+        :return: Dict, firmware version object
+        """
+
+        fw_version = {
+            "BIOS": self.get_bios_version(),
+            "CPLD": self.get_cpld_version()
+        }.get(module_name.upper(), None)
+
+        fw_dict = dict()
+        fw_dict["module_name"] = module_name
+        fw_dict["fw_version"] = fw_version
+        fw_dict["has_submodule"] = True if type(fw_version) is dict else False
+
+        return fw_dict
+
+    def install(self, module_name, image_path):
+        """
+        Install firmware to module
+
+        :param module_name: A string, name of module that need to install new firmware
+        :param image_path: A string, path to firmware image 
+        :return: Boolean
+        """
+        module_name = module_name.upper()
+
+        if module_name == "CPLD":
+            img_dir = os.path.dirname(image_path)
+            img_name = os.path.basename(image_path)
+            root, ext = os.path.splitext(img_name)
+            ext = ".vme" if ext == "" else ext
+            new_image_path = os.path.join(img_dir, (root.lower() + ext))
+            os.rename(image_path, new_image_path)
+            install_command = "ls"
+            install_command = "ispvm %s" % new_image_path
+        elif module_name == "BIOS":
+            click.echo("Not supported")
+            return False
+
+        return self.run_command(install_command)

--- a/device/celestica/x86_64-cel_e1031-r0/plugins/fwutil.py
+++ b/device/celestica/x86_64-cel_e1031-r0/plugins/fwutil.py
@@ -5,8 +5,13 @@ import subprocess
 import click
 import os
 
+try:
+    from sonic_fw.fw_manage_base import FwBase
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
 
-class FwUtil():
+
+class FwUtil(FwBase):
     """Platform-specific FwUtil class"""
 
     SUPPORTED_MODULES = ["BIOS", "CPLD"]

--- a/device/celestica/x86_64-cel_seastone-r0/plugins/fwutil.py
+++ b/device/celestica/x86_64-cel_seastone-r0/plugins/fwutil.py
@@ -5,8 +5,13 @@ import subprocess
 import click
 import os
 
+try:
+    from sonic_fw.fw_manage_base import FwBase
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
 
-class FwUtil():
+
+class FwUtil(FwBase):
     """Platform-specific FwUtil class"""
 
     CPLD_ADDR_MAPPING = {

--- a/device/celestica/x86_64-cel_seastone-r0/plugins/fwutil.py
+++ b/device/celestica/x86_64-cel_seastone-r0/plugins/fwutil.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python
+
+import sys
+import os.path
+import subprocess
+import click
+import os
+
+
+class FwUtil():
+    """Platform-specific FwUtil class"""
+
+    def __init__(self):
+        self.cpld_dx010_path = "/sys/devices/platform/dx010_cpld/getreg"
+        self.bios_version_path = "/sys/class/dmi/id/bios_version"
+
+    # Run bash command and print output to stdout
+    def run_command(self, command):
+        click.echo(click.style("Command: ", fg='cyan') +
+                   click.style(command, fg='green'))
+
+        proc = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE)
+        (out, err) = proc.communicate()
+        click.echo("")
+        click.echo(out)
+
+        if proc.returncode != 0:
+            return False
+        return True
+
+    # Read register and resurn value
+    def __get_register_value(self, path, register):
+        cmd = "echo {1} > {0}; cat {0}".format(path, register)
+        p = subprocess.Popen(
+            cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        raw_data, err = p.communicate()
+        if err is not '':
+            return None
+        return raw_data.strip()
+
+    # Get BIOS firmware version
+    def get_bios_version(self):
+        try:
+            with open(self.bios_version_path, 'r') as fd:
+                bios_version = fd.read()
+                return bios_version.strip()
+        except Exception, e:
+            return None
+
+    # Get CPLD firmware version
+    def get_cpld_version(self):
+        try:
+            CPLD_1 = self.__get_register_value(self.cpld_dx010_path, '0x100')
+            CPLD_2 = self.__get_register_value(self.cpld_dx010_path, '0x200')
+            CPLD_3 = self.__get_register_value(self.cpld_dx010_path, '0x280')
+            CPLD_4 = self.__get_register_value(self.cpld_dx010_path, '0x300')
+            CPLD_5 = self.__get_register_value(self.cpld_dx010_path, '0x380')
+
+            CPLD_1 = 'None' if CPLD_1 is 'None' else "{}.{}".format(
+                int(CPLD_1[2], 16), int(CPLD_1[3], 16))
+            CPLD_2 = 'None' if CPLD_2 is 'None' else "{}.{}".format(
+                int(CPLD_2[2], 16), int(CPLD_2[3], 16))
+            CPLD_3 = 'None' if CPLD_3 is 'None' else "{}.{}".format(
+                int(CPLD_3[2], 16), int(CPLD_3[3], 16))
+            CPLD_4 = 'None' if CPLD_4 is 'None' else "{}.{}".format(
+                int(CPLD_4[2], 16), int(CPLD_4[3], 16))
+            CPLD_5 = 'None' if CPLD_5 is 'None' else "{}.{}".format(
+                int(CPLD_5[2], 16), int(CPLD_5[3], 16))
+
+            cpld_version = dict()
+            cpld_version["CPLD1"] = CPLD_1
+            cpld_version["CPLD2"] = CPLD_2
+            cpld_version["CPLD3"] = CPLD_3
+            cpld_version["CPLD4"] = CPLD_4
+            cpld_version["CPLD5"] = CPLD_5
+            return cpld_version
+        except Exception, e:
+            return None
+
+    def get_module_list(self):
+        """
+        Retrieves the list of module that available on the device
+
+        :return: A list of module
+        """
+        return ["BIOS", "CPLD"]
+
+    def get_fw_version(self, module_name):
+        """
+        Retrieves the firmware version of module
+
+        :param module_name: A string, module name
+        :return: Dict, firmware version object
+        """
+
+        fw_version = {
+            "BIOS": self.get_bios_version(),
+            "CPLD": self.get_cpld_version()
+        }.get(module_name.upper(), None)
+
+        fw_dict = dict()
+        fw_dict["module_name"] = module_name
+        fw_dict["fw_version"] = fw_version
+        fw_dict["has_submodule"] = True if type(fw_version) is dict else False
+
+        return fw_dict
+
+    def install(self, module_name, image_path):
+        """
+        Install firmware to module
+
+        :param module_name: A string, name of module that need to install new firmware
+        :param image_path: A string, path to firmware image 
+        :return: Boolean
+        """
+        module_name = module_name.upper()
+
+        if module_name == "CPLD":
+            img_dir = os.path.dirname(image_path)
+            img_name = os.path.basename(image_path)
+            root, ext = os.path.splitext(img_name)
+            ext = ".vme" if ext == "" else ext
+            new_image_path = os.path.join(img_dir, (root.lower() + ext))
+            os.rename(image_path, new_image_path)
+            install_command = "ls"
+            install_command = "ispvm %s" % new_image_path
+        elif module_name == "BIOS":
+            click.echo("Not supported")
+            return False
+
+        return self.run_command(install_command)

--- a/platform/broadcom/sonic-platform-modules-cel/debian/platform-modules-dx010.init
+++ b/platform/broadcom/sonic-platform-modules-cel/debian/platform-modules-dx010.init
@@ -12,7 +12,8 @@
 ### END INIT INFO
 
 function export_gpio {
-label=$2
+label=$3
+gpio_dir=$2
 gpio_num=$1
 gpio_base=`( cat /sys/class/gpio/gpiochip*/base | head -1 ) 2>/dev/null`
 gpio_label=`( cat /sys/class/gpio/gpiochip*/label | head -1 ) 2>/dev/null`
@@ -26,6 +27,13 @@ echo $ionum > /sys/class/gpio/export
 if [ $? -ne 0 ]; then
         echo "Platform driver error: Cannot export gpio$ionum!"
         exit 1;
+fi
+if [[ "X$gpio_dir" != "X" ]]; then
+        echo $gpio_dir > /sys/class/gpio/gpio${ionum}/direction
+        if [ $? -ne 0 ]; then
+                echo "Platform driver error: Cannot set direction of gpio$ionum!"
+                exit 1;
+        fi
 fi
 }
 
@@ -95,27 +103,33 @@ start)
         sleep 2
 
         # Export platform gpio sysfs
-        export_gpio 10  # Fan 1 present
-        export_gpio 11  # Fan 2 present
-        export_gpio 12  # Fan 3 present
-        export_gpio 13  # Fan 4 present
-        export_gpio 14  # Fan 5 present
+        export_gpio 10 "in" # Fan 1 present
+        export_gpio 11 "in" # Fan 2 present
+        export_gpio 12 "in" # Fan 3 present
+        export_gpio 13 "in" # Fan 4 present
+        export_gpio 14 "in" # Fan 5 present
 
-        export_gpio 22  # PSU L PWOK
-        export_gpio 25  # PSU R PWOK
-        export_gpio 27  # PSU L ABS
-        export_gpio 28  # PSU R ABS
+        export_gpio 15 "in" # Fan 1 direction
+        export_gpio 16 "in" # Fan 2 direction
+        export_gpio 17 "in" # Fan 3 direction
+        export_gpio 18 "in" # Fan 4 direction
+        export_gpio 19 "in" # Fan 5 direction
 
-        export_gpio 29  # Fan 1 LED: Red
-        export_gpio 30  # Fan 1 LED: Yellow
-        export_gpio 31  # Fan 2 LED: Red
-        export_gpio 32  # Fan 2 LED: Yellow
-        export_gpio 33  # Fan 3 LED: Red
-        export_gpio 34  # Fan 3 LED: Yellow
-        export_gpio 35  # Fan 4 LED: Red
-        export_gpio 36  # Fan 4 LED: Yellow
-        export_gpio 37  # Fan 5 LED: Red
-        export_gpio 38  # Fan 5 LED: Yellow
+        export_gpio 22 "in" # PSU L PWOK
+        export_gpio 25 "in" # PSU R PWOK
+        export_gpio 27 "in" # PSU L ABS
+        export_gpio 28 "in" # PSU R ABS
+
+        export_gpio 29 "out" # Fan 1 LED: Red
+        export_gpio 30 "out" # Fan 1 LED: Yellow
+        export_gpio 31 "out" # Fan 2 LED: Red
+        export_gpio 32 "out" # Fan 2 LED: Yellow
+        export_gpio 33 "out" # Fan 3 LED: Red
+        export_gpio 34 "out" # Fan 3 LED: Yellow
+        export_gpio 35 "out" # Fan 4 LED: Red
+        export_gpio 36 "out" # Fan 4 LED: Yellow
+        export_gpio 37 "out" # Fan 5 LED: Red
+        export_gpio 38 "out" # Fan 5 LED: Yellow
 
         # Turn off/down lpmod by defult (0 - Normal, 1 - Low Pow)
         echo 0x00000000 > /sys/devices/platform/dx010_cpld/qsfp_lpmode


### PR DESCRIPTION
**- What I did**

- Add platform-specific firmware management API

**- How I did it**
- Add support for query querying BIOS/CPLD version on HLX/SLX
- Add support for Install CPLD image on HLX/SLX

**- How to verify it**

- Use fwutil CLI (https://github.com/SW-CSV/sonic-utilities/pull/2)

```
root@sonic:~# fwutil show version
Module    Submodule    Version
--------  -----------  ---------
BIOS                   5.6.5
CPLD      CPLD4        4.4
CPLD      CPLD5        5.4
CPLD      CPLD2        2.5
CPLD      CPLD3        3.4
CPLD      CPLD1        1.4

root@sonic:~# fwutil install -m CPLD http://192.168.20.106/slx/Seastone_CPLD_V0_7.vme
Downloading image...
Command: ispvm /tmp/fw_image.vme

                 Lattice Semiconductor Corp.

             ispVME(tm) V12.2 Copyright 1998-2011.

For daisy chain programming of all in-system programmable devices

Processing virtual machine file (/tmp/fw_image.vme)......

CREATED BY: ispVM(R) System Version 18.0.1
CREATION DATE: 12/06/18 16:03:31  

+=======+
| PASS! |
+=======+

Done

```
